### PR TITLE
fix(soundness): disable interrupts on every `RefCell` flags change

### DIFF
--- a/src/interrupt_dropper.rs
+++ b/src/interrupt_dropper.rs
@@ -1,0 +1,50 @@
+use core::mem::ManuallyDrop;
+use core::ops::{Deref, DerefMut};
+
+/// A wrapper for dropping values while interrupts are disabled.
+pub struct InterruptDropper<T> {
+    inner: ManuallyDrop<T>,
+}
+
+impl<T> From<T> for InterruptDropper<T> {
+    #[inline]
+    fn from(value: T) -> Self {
+        Self {
+            inner: ManuallyDrop::new(value),
+        }
+    }
+}
+
+impl<T> InterruptDropper<T> {
+    #[inline]
+    pub fn into_inner(mut this: Self) -> T {
+        // SAFETY: We never use `this` after this again.
+        unsafe { ManuallyDrop::take(&mut this.inner) }
+    }
+}
+
+impl<T> Deref for InterruptDropper<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+
+impl<T> DerefMut for InterruptDropper<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.deref_mut()
+    }
+}
+
+impl<T> Drop for InterruptDropper<T> {
+    #[inline]
+    fn drop(&mut self) {
+        let _guard = interrupts::disable();
+        // Drop `inner` as while we can guarentee interrupts are disabled
+        // SAFETY: This is not exposed to safe code and is not called more than once
+        unsafe { ManuallyDrop::drop(&mut self.inner) }
+    }
+}

--- a/src/interrupt_dropper.rs
+++ b/src/interrupt_dropper.rs
@@ -42,9 +42,10 @@ impl<T> DerefMut for InterruptDropper<T> {
 impl<T> Drop for InterruptDropper<T> {
     #[inline]
     fn drop(&mut self) {
-        let _guard = interrupts::disable();
+        let guard = interrupts::disable();
         // Drop `inner` as while we can guarentee interrupts are disabled
         // SAFETY: This is not exposed to safe code and is not called more than once
         unsafe { ManuallyDrop::drop(&mut self.inner) }
+        drop(guard);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,13 +64,14 @@
 
 #[cfg(not(target_os = "none"))]
 mod local_key;
+
 use core::cell::{BorrowError, BorrowMutError, Ref, RefCell, RefMut};
 use core::cmp::Ordering;
 use core::ops::{Deref, DerefMut};
 use core::{fmt, mem};
 
 #[cfg(not(target_os = "none"))]
-pub use local_key::LocalKeyExt;
+pub use self::local_key::LocalKeyExt;
 
 /// A mutable memory location with dynamically checked borrow rules
 ///


### PR DESCRIPTION
The second commit is of importance.

Closes https://github.com/mkroening/interrupt-ref-cell/issues/5.